### PR TITLE
Update Google maps to 2.6.0

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - GoogleMaps (2.5.0):
-    - GoogleMaps/Maps (= 2.5.0)
-  - GoogleMaps/Base (2.5.0)
-  - GoogleMaps/Maps (2.5.0):
+  - GoogleMaps (2.6.0):
+    - GoogleMaps/Maps (= 2.6.0)
+  - GoogleMaps/Base (2.6.0)
+  - GoogleMaps/Maps (2.6.0):
     - GoogleMaps/Base
-  - RxCocoa (4.0.0):
+  - RxCocoa (4.1.2):
     - RxSwift (~> 4.0)
-  - RxGoogleMaps (3.0.0):
-    - GoogleMaps (~> 2.5.0)
+  - RxGoogleMaps (3.0):
+    - GoogleMaps (~> 2.6.0)
     - RxCocoa (~> 4.0)
     - RxSwift (~> 4.0)
-  - RxSwift (4.0.0)
+  - RxSwift (4.1.2)
 
 DEPENDENCIES:
   - RxGoogleMaps (from `./`)
@@ -20,11 +20,11 @@ EXTERNAL SOURCES:
     :path: ./
 
 SPEC CHECKSUMS:
-  GoogleMaps: c087b8e5dfe87ca6ebf59adb9b4894a4146bec4f
-  RxCocoa: d62846ca96495d862fa4c59ea7d87e5031d7340e
-  RxGoogleMaps: 4292d12054bbd652967cb4da399a4992fe5d3bd8
-  RxSwift: fd680d75283beb5e2559486f3c0ff852f0d35334
+  GoogleMaps: 42f91c68b7fa2f84d5c86597b18ceb99f5414c7f
+  RxCocoa: d88ba0f1f6abf040011a9eb4b539324fc426843a
+  RxGoogleMaps: 0f2761d688b97296f14dc8a505c12a4c788e9bcc
+  RxSwift: e49536837d9901277638493ea537394d4b55f570
 
 PODFILE CHECKSUM: 8926bb4f317d1813c964a7c97038b24441fbcde8
 
-COCOAPODS: 1.4.0.beta.2
+COCOAPODS: 1.4.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - GoogleMaps/Base
   - RxCocoa (4.1.2):
     - RxSwift (~> 4.0)
-  - RxGoogleMaps (3.0):
+  - RxGoogleMaps (3.0.1):
     - GoogleMaps (~> 2.6.0)
     - RxCocoa (~> 4.0)
     - RxSwift (~> 4.0)
@@ -22,7 +22,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   GoogleMaps: 42f91c68b7fa2f84d5c86597b18ceb99f5414c7f
   RxCocoa: d88ba0f1f6abf040011a9eb4b539324fc426843a
-  RxGoogleMaps: 0f2761d688b97296f14dc8a505c12a4c788e9bcc
+  RxGoogleMaps: 35ac8f51dc37e2b2ca0bf475ddd713a96ad896a6
   RxSwift: e49536837d9901277638493ea537394d4b55f570
 
 PODFILE CHECKSUM: 8926bb4f317d1813c964a7c97038b24441fbcde8

--- a/RxGoogleMaps-iOS/Info.plist
+++ b/RxGoogleMaps-iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/RxGoogleMaps.podspec
+++ b/RxGoogleMaps.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "RxGoogleMaps"
-  s.version          = "3.0"
+  s.version          = "3.0.1"
   s.summary          = "RxSwift reactive wrapper for GoogleMaps SDK."
   s.homepage         = "https://github.com/RxSwiftCommunity/RxGoogleMaps"
   s.license          = 'MIT'

--- a/RxGoogleMaps.podspec
+++ b/RxGoogleMaps.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
   s.dependency 'RxSwift', '~> 4.0'
   s.dependency 'RxCocoa', '~> 4.0'
-  s.dependency 'GoogleMaps', '~> 2.5.0'
+  s.dependency 'GoogleMaps', '~> 2.6.0'
 
   s.pod_target_xcconfig = {
     'SWIFT_VERSION' => '4.0'

--- a/RxGoogleMaps.xcodeproj/project.pbxproj
+++ b/RxGoogleMaps.xcodeproj/project.pbxproj
@@ -252,7 +252,7 @@
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleMaps.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
Hi, this updates the GoogleMaps cocoapods dependency to 2.6.0.

Not sure if I'm supposed to do this but I've updated the podspec to 3.0.1 as well.

https://developers.google.com/maps/documentation/ios-sdk/releases